### PR TITLE
set up for being built independently of a kernel build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.*.cmd
+.tmp_versions
+*Module.symvers
+modules.order
+*.ko
+*.mod.c
+*.mod.o
+*.o
+from-kernel

--- a/README.md
+++ b/README.md
@@ -1,5 +1,66 @@
 # snd-digitakt
 ALSA driver for the Elektron Digitakt
 
+## Build as an installable kernel module on a running system
+
+The driver can now be built on your system without pulling an entire kernel
+tree. However, the build requires two files from the kernel tree that are
+not normally exported into the kernel headers package. The build will
+attempt to grab them from github. If that doesn't work right, you may need
+to find them yourself. See the Makefile.
+
+### Build
+
+    cd sound/usb/misc
+	make
+
+At this point you could simply manually install the module into your kernel:
+
+    insmod snd-digitakt.ko
+
+But, you probably want to install it...
+
+### Install
+
+    sudo make install
+
+### Load it
+
+    sudo modprobe snd-digitakt
+
+
+### Run it
+
+1. Connect your Digitakt
+2. Put it in Overbridge mode
+   * Settings (gear button) > System > USB Config
+   * Select Overbridge, press Yes
+   * Select Int to Main, set to Off
+
+Now you should be able to see the device in ALSA's utitlies:
+
+    aplay -l
+	arecord -l
+
+If you want to use Jack with it, try something like this:
+
+    /usr/bin/jackd -R -P 75 -d alsa -d hw:Digitakt -r 48000 -n 2 -p 256 -s &
+
+
+### Test with SuperCollider
+
+Run `sclang`, then type the following to it:
+
+    s.options.numInputBusChannels = 12
+	s.boot
+	{ SoundIn.ar([0, 1]_; }.play   // plays master bus out to Digitakt's outs
+	CmdPeriod.run                  // stop that
+	{ SoundIn.ar([2, 3]_; }.play   // plays tracks 1 and 2 to Digitakt's outs
+	CmdPeriod.run                  // stop that
+	{ SoundIn.ar([10, 11]_; }.play // plays Digitakt's ins to Digitakt's outs 
+	CmdPeriod.run                  // stop that
+
+## Previous build instructions, if you need them
+
 Build instructions for Raspberry (tnx mzero!)
 https://gist.github.com/mzero/b8d772cd78867a3215fcd7a0e42add51

--- a/sound/usb/misc/Makefile
+++ b/sound/usb/misc/Makefile
@@ -1,5 +1,33 @@
-snd-ua101-objs := ua101.o
-obj-$(CONFIG_SND_USB_UA101) += snd-ua101.o
 snd-digitakt-objs := digitakt.o
-obj-$(CONFIG_SND_USB_DIGITAKT) += snd-digitakt.o
+obj-m+=snd-digitakt.o
+
+kernel_build := /lib/modules/$(shell uname -r)/build
+mod_dir := $(shell pwd)
+mod_make := make -C $(kernel_build) M=$(mod_dir)
+
+all:
+	$(mod_make) modules
+
+clean:
+	$(mod_make) clean
+
+install: all
+	$(mod_make) modules_install
+	depmod
+
+
+kernel_version := $(shell dpkg-query --show --showformat='$${Version}' \
+	'raspberrypi-kernel-headers*' | sed -e 's/~stretch//')
+kernel_repo := https://github.com/raspberrypi/linux
+kernel_branch := $(kernel_repo)/raw/raspberrypi-kernel_$(kernel_version)
+
+from-kernel:
+	mkdir -p $@ 2>&1 || true
+
+from-kernel/%.h: from-kernel
+	curl -o $@ -L $(kernel_branch)/sound/usb/$*.h
+
+extra-kernel-headers: from-kernel/midi.h from-kernel/usbaudio.h
+
+digitakt.o: extra-kernel-headers
 

--- a/sound/usb/misc/digitakt.c
+++ b/sound/usb/misc/digitakt.c
@@ -24,8 +24,8 @@
 #include <sound/initval.h>
 #include <sound/pcm.h>
 #include <sound/pcm_params.h>
-#include "../usbaudio.h"
-#include "../midi.h"
+#include "from-kernel/usbaudio.h"
+#include "from-kernel/midi.h"
 
 MODULE_DESCRIPTION("Elektron Digitakt driver");
 MODULE_AUTHOR("Stefan Rehm <droelfdroelf@gmail.com>");


### PR DESCRIPTION
This CL lets users build the module in place without having to manually pull a kernel tree and merge the files into that tree.

1) The two required .h files are now fetched from the kernel sources matching the installed kernel headers. `digitakt.c` is altered to use these files.
2) The `Makefile` handles building the module in-place.

Future issues: This code probably isn't graceful if the user doesn't have the right kernel headers installed.